### PR TITLE
Define 'arrowParens': 'always'

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,5 +3,6 @@
     "printWidth": 100,
     "semi": false,
     "singleQuote": true,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "arrowParens": "always"
 }


### PR DESCRIPTION
The default value of [arrowParens](https://prettier.io/docs/en/options.html#arrow-function-parentheses) varies depends on the version of prettier
- `v1.9.0`: `avoid`
- `v2.0.0`: `always`

So it is possible that different codebases could have different parameter styles based on the version of prettier used. This could have the issues that
- Different repo could have a different style, even though same config is used
- It is possible that one would use the global prettier CLI to format the code (i.e. some editor could use it). So it is possible that the global prettier version could affect the styling of the code. 

The PR address the issue by defining the value of `arrowParens` to `always`, so that the resulting code style is always consistent despite the prettier version. 


