### PR TITLE
Specify peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "bugs": {
         "url": "https://github.com/Doist/prettier-config/issues"
     },
-    "homepage": "https://github.com/Doist/prettier-config#readme"
+    "homepage": "https://github.com/Doist/prettier-config#readme",
+    "peerDependencies": {
+        "prettier": "^1.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     },
     "homepage": "https://github.com/Doist/prettier-config#readme",
     "peerDependencies": {
-        "prettier": "^1.0.0"
+        "prettier": "^2.0.0"
     }
 }


### PR DESCRIPTION
As discussed [here](https://github.com/Doist/prettier-config/pull/8) using a different version of `prettier` causes trouble with sharing config. Let's add `peerDependencies`. In case of mismatch, it's only a warning, but it's better than nothing and a it documents desired version.