### PR TITLE
Add action to publish to both npm and GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Release @doist/prettier-config package
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            # Publish to npm registry
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+                  registry-url: https://registry.npmjs.org
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+            # Publish to GitHub package registry
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+                  registry-url: https://npm.pkg.github.com
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## 3.0.0 (July 7, 2020)
+
+* Pinned `prettier` as a peer dependency at `^2.0.0` [#9](https://github.com/Doist/prettier-config/pull/9)
+
+## 2.1.0 (June 23, 2020)
+
+* Set `arrowParens` to `always` [#8](https://github.com/Doist/prettier-config/pull/8)
+
+## 2.0.0  (June 4, 2020)
+
+* Added documentation for release process [#7](https://github.com/Doist/prettier-config/pull/7)
+* Set `trailingComma` to `all` [#5](https://github.com/Doist/prettier-config/pull/5)
+
+## 1.0.0  (May 26, 2020)
+
+* Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1 (July 7, 2020)
+
+* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10)
+
 ## 3.0.0 (July 7, 2020)
 
 * Pinned `prettier` as a peer dependency at `^2.0.0` [#9](https://github.com/Doist/prettier-config/pull/9)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ npm install --save-dev @doist/prettier-config
 
 ## Release a new package
 
-This project uses [sementic versioning](https://semver.org/).
+This project uses [sementic versioning](https://semver.org/). A new version will be published to both npm and GitHub Package Registry when a new tag is pushed.
 
 ```
-npm version major
-npm publish
-git push
+npm version <major|minor|patch>
+git push origin --tags
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save-dev @doist/prettier-config
 
 ## Release a new package
 
-This project uses [sementic versioning](https://semver.org/). A new version will be published to both npm and GitHub Package Registry when a new tag is pushed.
+This project uses [sementic versioning](https://semver.org/). A new version will be published to both npm and GitHub Package Registry when a new tag is pushed. Please make sure an entry is added to [CHANGELOG.md](CHANGELOG.md)
 
 ```
 npm version <major|minor|patch>


### PR DESCRIPTION
With this change, a new version should be published to both registries once a new tag has been pushed to Github. Hopefully, this works on the first try 🤞

