### PR TITLE
Fix publishing to GitHub/npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,20 +11,15 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            # Publish to npm registry
+            # Publish to GitHub package registry using .npmrc
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-                  registry-url: https://registry.npmjs.org
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-            # Publish to GitHub package registry
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12
-                  registry-url: https://npm.pkg.github.com
             - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+            # Publish to npm registry
+            - run: npm publish --@doist:registry=https://registry.npmjs.org/
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.0.1 (July 7, 2020)
+## 3.0.2 (July 7, 2020)
 
-* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10)
+* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10), [#11](https://github.com/Doist/prettier-config/pull/11)
 
 ## 3.0.0 (July 7, 2020)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm install --save-dev @doist/prettier-config
 This project uses [sementic versioning](https://semver.org/). A new version will be published to both npm and GitHub Package Registry when a new tag is pushed. Please make sure an entry is added to [CHANGELOG.md](CHANGELOG.md)
 
 ```
+git checkout master
 npm version <major|minor|patch>
-git push origin --tags
+git push --follow-tags
 ```


### PR DESCRIPTION
The [previous run](https://github.com/Doist/prettier-config/runs/844397030?check_suite_focus=true) failed with `npm ERR! Unable to authenticate, need: Basic realm="GitHub Package Registry"`, which looks like it was still trying to authenticate with GitHub when first trying to publish to npm. I found a [comment](https://github.com/actions/setup-node/issues/52#issuecomment-536544414) (From Kyle Simpson) that suggested to use a cli flag to override our local .npmrc. So here goes attempt number 2 🤞