### PR TITLE
Fix GitHub/npm publishing round 2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            # Publish to GitHub package registry using .npmrc
+            # Publish to GitHub package registry
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
+                  registry-url: https://npm.pkg.github.com/
             - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.pkg.github.com/doist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.0.2 (July 7, 2020)
+## 3.0.3 (July 7, 2020)
 
-* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10), [#11](https://github.com/Doist/prettier-config/pull/11)
+* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10), [#11](https://github.com/Doist/prettier-config/pull/11), [#12](https://github.com/Doist/prettier-config/pull/12)
 
 ## 3.0.0 (July 7, 2020)
 


### PR DESCRIPTION
It looks like just running `npm publish` with an .npmrc file in place wasn't enough. This attempt will remove .npmrc and specify the `package-url` when initially running `setup-node`, which is the exact same set up as reactist which worked previously.
