### PR TITLE
Fix GitHub/npm publishing round 3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,17 @@ jobs:
               with:
                   node-version: 12
                   registry-url: https://npm.pkg.github.com/
+                  scope: '@doist'
             - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
             # Publish to npm registry
-            - run: npm publish --@doist:registry=https://registry.npmjs.org/
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+                  registry-url: https://registry.npmjs.org/
+                  scope: '@doist'
+            - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.0.4 (July 7, 2020)
+## 3.0.5 (July 7, 2020)
 
-* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10), [#11](https://github.com/Doist/prettier-config/pull/11), [#12](https://github.com/Doist/prettier-config/pull/12)
+* Published to npm [#10](https://github.com/Doist/prettier-config/pull/10), [#11](https://github.com/Doist/prettier-config/pull/11), [#12](https://github.com/Doist/prettier-config/pull/12), [#13](https://github.com/Doist/prettier-config/pull/13)
 
 ## 3.0.0 (July 7, 2020)
 


### PR DESCRIPTION
The previous attempt in #12 succeeded in publishing to Github, but failed to publish to npm:

```
npm ERR! 404  '@doist/prettier-config@3.0.3' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```

I ran `npm publish` locally with the `--access public` flag set to true which succeeded, and subsequent runs shouldn't need that flag anymore. 

It might also have been a problem with the .npmrc that was created with the setup-node task, so I've pulled it in again for npm to hopefully override the current temporary copy created for GitHub.