### PR TITLE
feat: Set `html` parser on .svg files.

### DIFF
--- a/index.json
+++ b/index.json
@@ -4,5 +4,13 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "all",
-    "arrowParens": "always"
+    "arrowParens": "always",
+    "overrides": [
+        {
+            "files": "*.svg",
+            "options": {
+                "parser": "html"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Set `html` parser on .svg files. This isn't quite technically correct, but at the moment prettier does not support xml files and we are already (ab)using it this way, [ref.](https://github.com/Doist/todoist-web/blob/1cf95ea21477a551cd4b7f8db990ce1c827f7f17/package.json#L51)

By specifying this here, we can simplify `package.json` scripts by removing the need for separate svg step.