### PR TITLE
feat!: Update `prettier` peer dependency to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,31 @@
 {
     "name": "@doist/prettier-config",
     "version": "3.0.5",
-    "lockfileVersion": 1
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@doist/prettier-config",
+            "version": "3.0.5",
+            "license": "MIT",
+            "peerDependencies": {
+                "prettier": "^2.0.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "peer": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     },
     "homepage": "https://github.com/Doist/prettier-config#readme",
     "peerDependencies": {
-        "prettier": "^2.0.0"
+        "prettier": "^3.0.0"
     }
 }


### PR DESCRIPTION
This is a breaking change:

- https://prettier.io/blog/2023/07/05/3.0.0.html