### PR TITLE
ci: Enable trusted publishing and npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,29 +5,47 @@ on:
         tags:
             - 'v*'
 
+permissions:
+    # Enable reading repository contents (allows checkout without token)
+    contents: read
+    # Enable the use of OIDC for trusted publishing and npm provenance
+    id-token: write
+    # Enable the use of GitHub Packages registry
+    packages: write
+
 jobs:
     publish:
         runs-on: ubuntu-latest
         timeout-minutes: 60
-        steps:
-            - uses: actions/checkout@v4
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
 
-            # Publish to GitHub package registry
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12
-                  registry-url: https://npm.pkg.github.com/
-                  scope: '@doist'
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        - name: Setup Node
+          uses: actions/setup-node@v3
+          with:
+              node-version: 24
 
-            # Publish to npm registry
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12
-                  registry-url: https://registry.npmjs.org/
-                  scope: '@doist'
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+        - name: Ensure npm 11.5.1 or later is installed
+          run: npm install -g npm@latest
+
+        - name: Publish to GitHub Package Registry
+          uses: actions/setup-node@v3
+          with:
+              node-version: 24
+              registry-url: https://npm.pkg.github.com/
+              scope: '@doist'
+        - run: npm publish
+          env:
+              NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Clear npm config between GitHub/npm registries
+          run: rm -f $NPM_CONFIG_USERCONFIG
+
+        - name: Publish to npm registry
+          uses: actions/setup-node@v3
+          with:
+              node-version: 24
+              registry-url: https://registry.npmjs.org/
+              scope: '@doist'
+        - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@doist/prettier-config",
     "version": "4.0.0",
-    "description": "> Doist global [prettier](https://prettier.io) config.",
+    "description": "Doist global [prettier](https://prettier.io) config.",
     "main": "index.json",
-    "repository": "git@github.com:doist/prettier-config.git",
+    "repository": "https://github.com/Doist/prettier-config",
     "author": "David Miotti <davidm@doist.com>",
     "license": "MIT",
     "bugs": {


### PR DESCRIPTION
This PR updates the repository’s GitHub Actions workflow to use **npm’s Trusted Publishing** feature for package releases. Using Trusted Publishing eliminates the need to store long-lived npm tokens in GitHub secrets, reducing security risks and simplifying credential management. This also standardizes the publishing process across repositories.

> [!IMPORTANT]
> The npm organization and repository must be linked and authorized for Trusted Publishing before merging.

**What’s changing:**

* Replaces manual `NPM_TOKEN` authentication with GitHub’s **OpenID Connect (OIDC)**–based authentication.
* Updates the release workflow configuration to align with [npm’s Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)
* Ensures that package publishing permissions are managed directly through GitHub and npm, improving security and maintainability.